### PR TITLE
MISLEADING IOS INSTRUCTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ The adapter does its magic by swizzling a few method and adding another set of m
 First, make sure you have the 2.x version of React Native Navigation installed.
 
 ```
-npm install --save react-native-navigation
+npm install --save react-native-navigation@2
 ```
 
 or
 
 ```
-yarn add react-native-navigation
+yarn add react-native-navigation@2
 ```
 
 


### PR DESCRIPTION
If you remove the 1x version, you are left with no version at all.
- With two separate attempts on two different major version releases of RN, I was not able to locate the desired xcodeproj file following the instructions to the tee.  If you first install RNN 2.x there will not be an issue with this.
- Updated README.md to reflect