### PR TITLE
update switchToTab to use fix correct object value

### DIFF
--- a/navigatorBridge.js
+++ b/navigatorBridge.js
@@ -147,9 +147,9 @@ export function generateNavigator(componentId) {
         }
       });
     },
-    switchToTab(tabIndex) {
-      const options = tabIndex ? {
-        currentTabIndex: tabIndex
+    switchToTab(tab) {
+      const options = tab ? {
+        currentTabIndex: tab.tabIndex
       } : {
           currentTabId: this.id
         };


### PR DESCRIPTION
Fixes https://github.com/wix-playground/react-native-navigation-v1-v2-adapter/issues/5